### PR TITLE
Translates Chinese text to English

### DIFF
--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -96,7 +96,7 @@ The main fields reported in data statistics include:
 | libraryCode | library code | |
 | componentName | component name | Only the installation type is determined by this value |
 | componentCode | component code | |
-| type | 操作类型 | 0（view library）、1（install component）、2（view document）、3（insert snippet） |
+| type | The type of operation | 0（view library）、1（install component）、2（view document）、3（insert snippet） |
 
 
 ```javascript


### PR DESCRIPTION
English/英语:
Fixes issue #2 by translating Chinese text to English in Docs

Chinese/中文:
通过在英文自述文件中将中文文本翻译成英文来修复问题 #2。